### PR TITLE
Better status

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ track stop
 
 #### `status`
 
-`status` simply informs about any running record:
+`status` informs about the running project:
 
 ```shell
 track status
@@ -66,8 +66,11 @@ track status
 
 Prints something like:
 
-```shell
-Tracking project 'MyProject' since 08:10 (00:45)
+```text
++------------------+-------+-------+-------+
+|          project |  curr | today | break |
+|        MyProject | 00:30 | 01:45 | 00:13 |
++------------------+-------+-------+-------+
 ```
 
 #### `list`

--- a/cli/status.go
+++ b/cli/status.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/mlange-42/track/core"
 	"github.com/mlange-42/track/out"
 	"github.com/mlange-42/track/util"
@@ -9,20 +11,82 @@ import (
 
 func statusCommand(t *core.Track) *cobra.Command {
 	status := &cobra.Command{
-		Use:     "status",
-		Short:   "Reports current status",
+		Use:     "status [PROJECT]",
+		Short:   "Reports the status of the running or given project",
 		Aliases: []string{"s"},
+		Args:    util.WrappedArgs(cobra.MaximumNArgs(1)),
 		Run: func(cmd *cobra.Command, args []string) {
-			if rec, ok := t.OpenRecord(); ok {
-				out.Print(
-					"Tracking project '%s' since %s (%s)",
-					rec.Project,
-					rec.Start.Format(util.TimeFormat),
-					util.FormatDuration(rec.Duration()),
-				)
+			var project string
+			open, hasOpenRecord := t.OpenRecord()
+			if len(args) > 0 {
+				project = args[0]
+				if hasOpenRecord && open.Project != project {
+					hasOpenRecord = false
+				}
+			} else {
+				if !hasOpenRecord {
+					out.Err("No running record. Start tracking or specify a project.")
+					return
+				}
+				project = open.Project
+			}
+
+			now := time.Now()
+			start := util.Date(now.Date())
+			filterStart := start.Add(-time.Hour * 24)
+
+			filters := core.FilterFunctions{
+				core.FilterByTime(filterStart, time.Time{}),
+			}
+
+			reporter, err := core.NewReporter(t, []string{project}, filters)
+			if err != nil {
+				out.Err("failed to show status: %s", err)
 				return
 			}
-			out.Print("No running record")
+
+			prevEnd := time.Time{}
+			currTime := time.Second * 0
+			totalTime := time.Second * 0
+			breakTime := time.Second * 0
+
+			for _, rec := range reporter.Records {
+				endTime := rec.End
+				if endTime.IsZero() {
+					endTime = now
+				} else {
+					if endTime.Before(start) {
+						continue
+					}
+				}
+				startTime := rec.Start
+				if startTime.Before(start) {
+					startTime = start
+				}
+
+				worked := endTime.Sub(startTime)
+
+				totalTime += worked
+				if rec.End.IsZero() {
+					currTime += worked
+				}
+
+				if !prevEnd.IsZero() {
+					breakTime += startTime.Sub(prevEnd)
+				}
+
+				prevEnd = endTime
+			}
+			out.Print("+------------------+-------+-------+-------+\n")
+			out.Print("|          project |  curr | today | break |\n")
+			out.Print(
+				"| %16s | %s | %s | %s |\n",
+				project,
+				util.FormatDuration(currTime),
+				util.FormatDuration(totalTime),
+				util.FormatDuration(breakTime),
+			)
+			out.Print("+------------------+-------+-------+-------+")
 		},
 	}
 

--- a/core/filter.go
+++ b/core/filter.go
@@ -31,8 +31,16 @@ func FilterByProjects(projects []string) FilterFunction {
 }
 
 // FilterByTime returns a function for filtering by time
+//
+// Keeps all records that are partially included in the given time span.
+// Zero times in the given time span are ignored, resulting in an open time span.
+//
+// For records with a zero end, only the start time is compared
 func FilterByTime(start, end time.Time) FilterFunction {
 	return func(r *Record) bool {
+		if r.End.IsZero() {
+			return (start.IsZero() || r.Start.After(start)) && (end.IsZero() || r.Start.Before(end))
+		}
 		return (start.IsZero() || r.End.After(start)) && (end.IsZero() || r.Start.Before(end))
 	}
 }

--- a/core/record.go
+++ b/core/record.go
@@ -25,18 +25,18 @@ var (
 // Record holds and manipulates data for a record
 type Record struct {
 	Project string
-	Note    string
-	Tags    []string
 	Start   time.Time
 	End     time.Time
+	Note    string
+	Tags    []string
 }
 
 type yamlRecord struct {
 	Project string
-	Note    string
-	Tags    []string
 	Start   util.Time
 	End     util.Time
+	Note    string
+	Tags    []string
 }
 
 // MarshalYAML converts a Record to YAML bytes

--- a/util/format.go
+++ b/util/format.go
@@ -34,6 +34,18 @@ func FormatDuration(d time.Duration) string {
 	return fmt.Sprintf("%02d:%02d", int(d.Hours()), int(d.Minutes())%60)
 }
 
+// Format formats a string with named placeholders.
+//
+// Example:
+// s := Format("foo {name} bar", map[string]string{"name": "baz"})
+func Format(str string, repl map[string]string) string {
+	format := "{%s}"
+	for k, v := range repl {
+		str = strings.ReplaceAll(str, fmt.Sprintf(format, k), v)
+	}
+	return str
+}
+
 // TreeFormatter formats trees
 type TreeFormatter[T tree.Named] struct {
 	NameFunc     func(t *tree.MapNode[T], indent int) string

--- a/util/format_test.go
+++ b/util/format_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormat(t *testing.T) {
+	assert.Equal(
+		t,
+		"foo baz bar",
+		Format("foo {name} bar", map[string]string{"name": "baz"}),
+		"Simple replacement not working",
+	)
+	assert.Equal(
+		t,
+		"foo baz bar baz",
+		Format("foo {name} bar {name}", map[string]string{"name": "baz"}),
+		"Repetitions not working",
+	)
+	assert.Equal(
+		t,
+		"foo baz bar foo",
+		Format("foo {name} bar {name2}", map[string]string{"name": "baz", "name2": "foo"}),
+		"Repetitions not working",
+	)
+}


### PR DESCRIPTION
Print status as a table, with current, today and break durations

```
+------------------+-------+-------+-------+
|          project |  curr | today | break |
|        MyProject | 00:30 | 01:45 | 00:13 |
+------------------+-------+-------+-------+
```