### PR TITLE
Resume with changed time

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -134,7 +134,7 @@ func getStopTime(open *core.Record, ago time.Duration, at string) (time.Time, er
 	return stopTime, nil
 }
 
-func getStartTime(latest *core.Record, ago time.Duration, at string) (time.Time, error) {
+func getStartTime(lastEnd time.Time, ago time.Duration, at string) (time.Time, error) {
 	now := time.Now()
 	startTime := now
 	if ago != 0 {
@@ -146,9 +146,9 @@ func getStartTime(latest *core.Record, ago time.Duration, at string) (time.Time,
 		if err != nil {
 			return time.Time{}, err
 		}
-		if latest != nil && startTime.After(now) {
+		if !lastEnd.IsZero() && startTime.After(now) {
 			altTime := startTime.Add(-24 * time.Hour)
-			if altTime.Before(now) && altTime.After(latest.End) {
+			if altTime.Before(now) && altTime.After(lastEnd) {
 				startTime = altTime
 			}
 		}
@@ -156,8 +156,8 @@ func getStartTime(latest *core.Record, ago time.Duration, at string) (time.Time,
 	if startTime.After(now) {
 		return startTime, fmt.Errorf("can't start at a time in the future")
 	}
-	if latest != nil && startTime.Before(latest.End) {
-		return startTime, fmt.Errorf("can't stop at a time before the end of the last record")
+	if !lastEnd.IsZero() && startTime.Before(lastEnd) {
+		return startTime, fmt.Errorf("can't start at a time before the last stop/pause")
 	}
 	return startTime, nil
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -60,13 +60,13 @@ Notes can contain tags, denoted by the prefix "%s", like "%stag"`, core.TagPrefi
 				return
 			}
 			if latest != nil {
-				startTime, err = getStartTime(latest, ago, atTime)
+				startTime, err = getStartTime(latest.End, ago, atTime)
 				if err != nil {
 					out.Err("failed to start record: %s", err.Error())
 					return
 				}
 			} else {
-				startTime, err = getStartTime(nil, ago, atTime)
+				startTime, err = getStartTime(time.Time{}, ago, atTime)
 				if err != nil {
 					out.Err("failed to start record: %s", err.Error())
 					return

--- a/cli/switch.go
+++ b/cli/switch.go
@@ -75,13 +75,13 @@ Notes can contain tags, denoted by the prefix "%s", like "%stag"`, core.TagPrefi
 					return
 				}
 				if latest != nil {
-					startStopTime, err = getStartTime(latest, ago, atTime)
+					startStopTime, err = getStartTime(latest.End, ago, atTime)
 					if err != nil {
 						out.Err("failed to create record: %s", err.Error())
 						return
 					}
 				} else {
-					startStopTime, err = getStartTime(nil, ago, atTime)
+					startStopTime, err = getStartTime(time.Time{}, ago, atTime)
 					if err != nil {
 						out.Err("failed to create record: %s", err.Error())
 						return

--- a/core/record.go
+++ b/core/record.go
@@ -55,6 +55,14 @@ func (r Record) IsPaused() bool {
 	return len(r.Pause) > 0 && r.Pause[len(r.Pause)-1].End.IsZero()
 }
 
+// CurrentPause returns the current pause
+func (r Record) CurrentPause() (Pause, bool) {
+	if len(r.Pause) > 0 && r.Pause[len(r.Pause)-1].End.IsZero() {
+		return r.Pause[len(r.Pause)-1], true
+	}
+	return Pause{}, false
+}
+
 // Duration reports the duration of a record
 func (r Record) Duration(min, max time.Time) time.Duration {
 	dur := util.DurationClip(r.Start, r.End, min, max)


### PR DESCRIPTION
Adds flags `--at` and `--ago` to the `resume` command