### PR TITLE
Revert comment and tag prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Switched to storing records in plain-text files with simple custom format (#52)
 * Pause times can now be stored inside records instead of stop/start for a pause (#52)
 * New command `pause` to pause a record, or insert a finished pause (#52)
-* The tag prefix is now `#` instead of `+` (record file comments are `//`) (#53)
+* ~~The tag prefix is now `#` instead of `+` (record file comments are `//`) (#53)~~ (#62)
 * Projects have a foreground color, in addition to the background color (#54)
 * The `resume` command has flags `--at` and `--ago` to correct times (#55)
 * The `start` command has a flag `--copy` to copy note and tags from the previous record in the same project (#58)

--- a/core/record.go
+++ b/core/record.go
@@ -15,10 +15,10 @@ import (
 )
 
 // TagPrefix denotes tags in record notes
-const TagPrefix = "#"
+const TagPrefix = "+"
 
 // CommentPrefix denotes comments in record files
-const CommentPrefix = "//"
+const CommentPrefix = "#"
 
 // YamlCommentPrefix denotes comments in YAML files
 const YamlCommentPrefix = "#"


### PR DESCRIPTION
Revert comment and tag prefix to `#` and `+` - sharp reserved in shell