### PR TITLE
Bugfix: Switch start with offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 * Command `track report day` now prints a schedule-like report similar to `week` (#63)
 * All `edit` subcommands have a flag `--dry` for dry-run (#68)
 * All `edit` subcommands re-open the edited file if parsing/checks fail; improved error messages (#69)
+
+### Bug fixes
+
+* Apply `--at`/`--ago` also to start time in `switch`, not only to end time of previous record (#74)
+
 ### Other
 
 * Removed command `break` (#52)

--- a/cli/switch.go
+++ b/cli/switch.go
@@ -92,7 +92,7 @@ Notes can contain tags, denoted by the prefix "%s", like "%stag"`, core.TagPrefi
 			note := strings.Join(args[1:], " ")
 			tags := core.ExtractTagsSlice(args[1:])
 
-			record, err := t.StartRecord(project, note, tags, time.Now())
+			record, err := t.StartRecord(project, note, tags, startStopTime)
 			if err != nil {
 				out.Err("failed to create record: %s", err.Error())
 				return


### PR DESCRIPTION
Fix switch with offset: apply also to start

Before, start would be now despite time/offset given