### PR TITLE
Tweak record editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 * Record that starts the day before is included in `list records [DATE]` command (#62)
 * Previous command `report day` (showing bar charts) renamed to `report chart` (#63)
 * Print the latest record in `status`, in the default plain-text format (#75)
+* Limit changes of end time when editing a single record (#76)
+* Allow date words like "yesterday" in record selection for editing (#76)
 
 ## [v0.2.1]
 

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -90,21 +90,26 @@ Uses the current date if only a time is given.`,
 				}
 				tm = util.DateAndTime(time.Now(), tm)
 			case 2:
-				timeString := strings.Join(args, " ")
-				tm, err = util.ParseDateTime(timeString)
+				date, err := util.ParseDate(args[0])
 				if err != nil {
 					out.Err("failed to edit record: %s", err)
 					return
 				}
+				tm, err = time.Parse(util.TimeFormat, args[1])
+				if err != nil {
+					out.Err("failed to edit record: %s", err)
+					return
+				}
+				tm = util.DateAndTime(date, tm)
 			}
 
 			err = editRecord(t, tm, *dryRun)
 			if err != nil {
 				if err == ErrUserAbort {
-					out.Warn("failed to edit record: %s", err)
+					out.Warn("failed to edit record %s: %s", tm.Format(util.DateTimeFormat), err)
 					return
 				}
-				out.Err("failed to edit record: %s", err)
+				out.Err("failed to edit record %s: %s", tm.Format(util.DateTimeFormat), err)
 				return
 			}
 			if *dryRun {

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -276,6 +276,18 @@ func editRecord(t *core.Track, tm time.Time, dryRun bool) error {
 			if newRecord.Start != record.Start {
 				return fmt.Errorf("can't change start time. Try command 'track edit day' instead")
 			}
+			if record.End.IsZero() {
+				if !newRecord.End.IsZero() && newRecord.End.After(time.Now()) {
+					return fmt.Errorf("can't set end time to the future. Try command 'track edit day' instead")
+				}
+			} else {
+				if newRecord.End.IsZero() {
+					return fmt.Errorf("can't open a finished record. Try command 'track edit day' instead")
+				}
+				if newRecord.End.After(record.End) {
+					return fmt.Errorf("can't extend record end time. Try command 'track edit day' instead")
+				}
+			}
 
 			if err = newRecord.Check(); err != nil {
 				return err

--- a/core/record.go
+++ b/core/record.go
@@ -26,6 +26,8 @@ const YamlCommentPrefix = "#"
 var (
 	// ErrNoRecords is an error for no records found for a date
 	ErrNoRecords = errors.New("no records for date")
+	// ErrRecordNotFound is an error for a particular record not found
+	ErrRecordNotFound = errors.New("record not found")
 )
 
 // Record holds and manipulates data for a record
@@ -390,6 +392,9 @@ func (t *Track) LoadRecord(tm time.Time) (Record, error) {
 	path := t.RecordPath(tm)
 	file, err := os.ReadFile(path)
 	if err != nil {
+		if _, ok := err.(*os.PathError); ok {
+			return Record{}, ErrRecordNotFound
+		}
 		return Record{}, err
 	}
 


### PR DESCRIPTION
* Limit changes of end time when editing a single record
* Allow date words like "yesterday" in record selection for editing