### PR TITLE
Report duration format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [[unpublished]](https://github.com/mlange-42/track/compare/v0.3.5...main)
 
-Nothing
+### Other
+
+* Durations are printed with space padding (` 1:23`) instead of zero-padding (`01:23`) in reports (#132)
 
 ## [[v0.3.5]](https://github.com/mlange-42/track/compare/v0.3.4...v0.3.5)
 

--- a/cli/list.go
+++ b/cli/list.go
@@ -254,9 +254,9 @@ func printRecord(r core.Record, project core.Project) {
 		}
 	}
 	out.Print(
-		"%s%s %s %s %s - %s (%s + %s)  %s\n", name, fill,
+		"%s%s %s %s %s - %s (%5s + %5s)  %s\n", name, fill,
 		project.Render.Sprintf(" %s ", project.Symbol),
-		date, start, end, util.FormatDuration(dur), util.FormatDuration(pause),
+		date, start, end, util.FormatDuration(dur, false), util.FormatDuration(pause, false),
 		note,
 	)
 }

--- a/cli/report_day_week.go
+++ b/cli/report_day_week.go
@@ -323,7 +323,7 @@ func renderWeekSchedule(t *core.Track, reporter *core.Reporter, active string, s
 		}
 
 		line1 += col.Sprintf(" %c:%3s ", symbols[indices[p]], p)
-		line2 += col.Sprintf(" %*s ", width+2, util.FormatDuration(reporter.TotalTime[p]))
+		line2 += col.Sprintf(" %*s ", width+2, util.FormatDuration(reporter.TotalTime[p], false))
 		lineWidth += width + 4
 	}
 	if len(line1) > 0 {

--- a/cli/report_projects.go
+++ b/cli/report_projects.go
@@ -80,7 +80,7 @@ func projectsReportCommand(t *core.Track, options *filterOptions) *cobra.Command
 					str += t.Value.Render.Sprintf(" %s ", t.Value.Symbol)
 
 					return fmt.Sprintf(
-						"%s %6s (%5s)", str,
+						"%s %6s (%6s)", str,
 						util.FormatDuration(reporter.TotalTime[t.Value.Name], false),
 						util.FormatDuration(reporter.ProjectTime[t.Value.Name], false),
 					)

--- a/cli/report_projects.go
+++ b/cli/report_projects.go
@@ -80,9 +80,9 @@ func projectsReportCommand(t *core.Track, options *filterOptions) *cobra.Command
 					str += t.Value.Render.Sprintf(" %s ", t.Value.Symbol)
 
 					return fmt.Sprintf(
-						"%s %s (%s)", str,
-						util.FormatDuration(reporter.TotalTime[t.Value.Name]),
-						util.FormatDuration(reporter.ProjectTime[t.Value.Name]),
+						"%s %6s (%5s)", str,
+						util.FormatDuration(reporter.TotalTime[t.Value.Name], false),
+						util.FormatDuration(reporter.ProjectTime[t.Value.Name], false),
 					)
 				},
 				2,

--- a/cli/report_tags.go
+++ b/cli/report_tags.go
@@ -124,10 +124,10 @@ func tagsReportCommand(t *core.Track, options *filterOptions) *cobra.Command {
 					str += strings.Repeat(" ", fillLen)
 				}
 				fmt.Printf(
-					"%s %3d  %s (%s)", str,
+					"%s %3d  %6s (%5s)", str,
 					stats.Count,
-					util.FormatDuration(stats.Work),
-					util.FormatDuration(stats.Pause),
+					util.FormatDuration(stats.Work, false),
+					util.FormatDuration(stats.Pause, false),
 				)
 				if !valueStats {
 					values := stats.Values
@@ -161,10 +161,10 @@ func tagsReportCommand(t *core.Track, options *filterOptions) *cobra.Command {
 							str += strings.Repeat(" ", fillLen)
 						}
 						fmt.Printf(
-							"  %s %3d  %s (%s)\n", str,
+							"  %s %3d  %6s (%5s)\n", str,
 							vStats.Count,
-							util.FormatDuration(vStats.Work),
-							util.FormatDuration(vStats.Pause),
+							util.FormatDuration(vStats.Work, false),
+							util.FormatDuration(vStats.Pause, false),
 						)
 					}
 				}

--- a/util/format.go
+++ b/util/format.go
@@ -21,6 +21,9 @@ const (
 	DateTimeFormat = "2006-01-02 15:04"
 	// NoTimeString string representation for zero end time
 	NoTimeString = " now "
+
+	durationFormatTemplate    = "%d:%02d"
+	durationFormatTemplatePad = "%02d:%02d"
 )
 
 const (
@@ -49,8 +52,11 @@ func FloatToBlock(value float64, space *rune) rune {
 }
 
 // FormatDuration formats a duration
-func FormatDuration(d time.Duration) string {
-	return fmt.Sprintf("%02d:%02d", int(d.Hours()), int(d.Minutes())%60)
+func FormatDuration(d time.Duration, zeroPadHours ...bool) string {
+	if len(zeroPadHours) > 0 && !zeroPadHours[0] {
+		return fmt.Sprintf(durationFormatTemplate, int(d.Hours()), int(d.Minutes())%60)
+	}
+	return fmt.Sprintf(durationFormatTemplatePad, int(d.Hours()), int(d.Minutes())%60)
 }
 
 // FormatTimeWithOffset formats a time with day offset indicators

--- a/util/format_test.go
+++ b/util/format_test.go
@@ -2,9 +2,82 @@ package util
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestFormatDuration(t *testing.T) {
+	tt := []struct {
+		title    string
+		dur      time.Duration
+		pad      bool
+		expected string
+	}{
+		{
+			title:    "padded hours",
+			dur:      time.Hour + 5*time.Minute,
+			pad:      true,
+			expected: "01:05",
+		},
+		{
+			title:    "padded hours, long numbers",
+			dur:      100*time.Hour + 5*time.Minute,
+			pad:      true,
+			expected: "100:05",
+		},
+		{
+			title:    "no padded hours",
+			dur:      time.Hour + 5*time.Minute,
+			pad:      false,
+			expected: "1:05",
+		},
+		{
+			title:    "no padded hours, long numbers",
+			dur:      100*time.Hour + 5*time.Minute,
+			pad:      false,
+			expected: "100:05",
+		},
+	}
+
+	for _, test := range tt {
+		str := FormatDuration(test.dur, test.pad)
+		assert.Equal(t, test.expected, str, "Wrong duration formatting in %s", test.title)
+	}
+}
+
+func TestFormatTimeWithOffset(t *testing.T) {
+	tt := []struct {
+		title    string
+		time     time.Time
+		ref      time.Time
+		expected string
+	}{
+		{
+			title:    "same day",
+			time:     DateTime(2001, 2, 3, 4, 5, 6),
+			ref:      Date(2001, 2, 3),
+			expected: "04:05",
+		},
+		{
+			title:    "previous day",
+			time:     DateTime(2001, 2, 3, 4, 5, 6),
+			ref:      Date(2001, 2, 4),
+			expected: "<04:05",
+		},
+		{
+			title:    "next day",
+			time:     DateTime(2001, 2, 3, 4, 5, 6),
+			ref:      Date(2001, 2, 2),
+			expected: "04:05>",
+		},
+	}
+
+	for _, test := range tt {
+		str := FormatTimeWithOffset(test.time, test.ref)
+		assert.Equal(t, test.expected, str, "Wrong duration formatting in %s", test.title)
+	}
+}
 
 func TestFormat(t *testing.T) {
 	assert.Equal(


### PR DESCRIPTION
* pad printed durations with spaces instead of zeros
* add formatting tests