### PR TITLE
[WIP]: feature: create records

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/mlange-42/track/core"
@@ -23,6 +24,7 @@ func createCommand(t *core.Track) *cobra.Command {
 
 	create.AddCommand(createWorkspaceCommand(t))
 	create.AddCommand(createProjectCommand(t))
+	create.AddCommand(createRecordCommand(t))
 	create.Long += "\n\n" + formatCmdTree(create)
 	return create
 }
@@ -94,4 +96,71 @@ func createWorkspaceCommand(t *core.Track) *cobra.Command {
 	}
 
 	return createWorkspace
+}
+
+func createRecordCommand(t *core.Track) *cobra.Command {
+	createRecord := &cobra.Command{
+		Use:     "record PROJECT DATE TIME_RANGE [NOTE...]",
+		Short:   "Create a new record for a project",
+		Aliases: []string{"p"},
+		Args:    util.WrappedArgs(cobra.MinimumNArgs(3)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			project := args[0]
+
+			if !t.ProjectExists(project) {
+				return fmt.Errorf("failed to create record: project '%s' does not exist", project)
+			}
+
+			proj, err := t.LoadProject(project)
+			if err != nil {
+				return fmt.Errorf("failed to create record: %w", err)
+			}
+
+			if proj.Archived {
+				return fmt.Errorf("failed to create record: project '%s' is archived", proj.Name)
+			}
+
+			date, err := util.ParseDate(args[1])
+			if err != nil {
+				return fmt.Errorf("failed to create record: %w", err)
+			}
+
+			start, end, err := util.ParseTimeRange(args[2], date)
+			if err != nil {
+				return fmt.Errorf("failed to create record: %w", err)
+			}
+
+			if start.After(end) {
+				return fmt.Errorf("failed to create record: start must be before end")
+			}
+
+			records, err := t.LoadAllRecordsFiltered(core.NewFilter([]core.FilterFunction{}, start, end))
+			if err != nil {
+				return fmt.Errorf("failed to create record: %w", err)
+			}
+
+			if len(records) > 0 {
+				return fmt.Errorf("failed to create record: time range overlaps with existing record(s)")
+			}
+
+			note := strings.Join(args[3:], " ")
+			tags, err := core.ExtractTagsSlice(args[3:])
+			if err != nil {
+				return fmt.Errorf("failed to create record: %w", err)
+			}
+
+			record, err := t.NewRecord(&proj, note, tags, start, end)
+			if err != nil {
+				return fmt.Errorf("failed to create record: %w", err)
+			}
+
+			year, month, day := record.Start.Date()
+			parsedDate := fmt.Sprintf("%d-%02d-%02d", year, month, day)
+
+			out.Success("Created record in '%s' at %s %02d:%02d - %02d:%02d", project, parsedDate, record.Start.Hour(), record.Start.Minute(), record.End.Hour(), record.End.Minute())
+			return nil
+		},
+	}
+
+	return createRecord
 }

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -96,3 +96,49 @@ func TestCreateProjectFlags(t *testing.T) {
 	}
 	assert.Equal(t, ref, project, "project properties differ from expected due to flags")
 }
+
+func TestCreateRecord(t *testing.T) {
+	track, err := setupTestCommand()
+	if err != nil {
+		t.Fatal("error setting up test")
+	}
+	defer os.Remove(track.RootDir)
+
+	cmd := RootCommand(track, "")
+	cmd.SetArgs([]string{"create", "project", "test"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal("error executing command")
+	}
+	assert.True(t, track.ProjectExists("test"), "Project should exist")
+
+	cmd.SetArgs([]string{"create", "record", "test", "today", "10:00-1h", "note"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("error executing command: %s", err)
+	}
+
+	records, err := track.LoadAllRecords()
+	if err != nil {
+		t.Fatal("error loading records")
+	}
+
+	assert.True(t, len(records) == 1, "Record should exist")
+	assert.Equal(t, records[0].Note, "note", "Note should be 'note'")
+
+	cmd.SetArgs([]string{"create", "record", "test", "today", "10:00-1h", "note"})
+	assert.NotNil(t, cmd.Execute(), "should fail with record time overlap error")
+
+	cmd.SetArgs([]string{"create", "record", "test", "2015-10-21", "16:29-19:28", "back to the future"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("error executing command: %s", err)
+	}
+
+	records, err = track.LoadAllRecords()
+	if err != nil {
+		t.Fatal("error loading records")
+	}
+
+	assert.True(t, len(records) == 2, "Records should exist")
+	assert.Equal(t, records[0].Note, "back to the future", "Note should be 'back to the future'")
+	assert.Equal(t, records[1].Note, "note", "Note should be 'note'")
+}

--- a/core/record_file.go
+++ b/core/record_file.go
@@ -28,14 +28,14 @@ type listFilterResult struct {
 	Err  error
 }
 
-// StartRecord starts and saves a new record
-func (t *Track) StartRecord(project *Project, note string, tags map[string]string, start time.Time) (Record, error) {
+// NewRecord creates a new record
+func (t *Track) NewRecord(project *Project, note string, tags map[string]string, start time.Time, end time.Time) (Record, error) {
 	record := Record{
 		Project: project.Name,
 		Note:    note,
 		Tags:    tags,
 		Start:   start,
-		End:     util.NoTime,
+		End:     end,
 		Pause:   []Pause{},
 	}
 
@@ -44,6 +44,11 @@ func (t *Track) StartRecord(project *Project, note string, tags map[string]strin
 	}
 
 	return record, t.SaveRecord(&record, false)
+}
+
+// StartRecord starts a new record for the given project at the given time.
+func (t *Track) StartRecord(project *Project, note string, tags map[string]string, start time.Time) (Record, error) {
+	return t.NewRecord(project, note, tags, start, util.NoTime)
 }
 
 // StopRecord stops the currently running record at the given time, and saves it to disk.

--- a/docs/src/projects.md
+++ b/docs/src/projects.md
@@ -22,7 +22,7 @@ archived: false
 
 ## Creating projects
 
-Most simple, a project with default properties can be created like this:
+To simply create a project with default properties, us the the following command:
 
 ```shell
 track create project MyProject

--- a/docs/src/tracking.md
+++ b/docs/src/tracking.md
@@ -25,7 +25,7 @@ track start MyProject
 
 ## Note and tags
 
-Records can have a not and tags.
+Records can have a note and tags.
 All positional arguments after the project's name are concatenated to the note text.
 Words prefixed with '+' are extracted as tags.
 Here is an example:


### PR DESCRIPTION
# Motivation
When using time tracking tools it might happen that you are not able to start your records on time because you are in meetings or aren't able to access your device at that time. Therefore it is quite useful to be able to create records retrospectively.

# Solution
Extended the `track create` command with `track create record PROJECT DATE TIME_RANGE [NOTE...]`

Examples:
```bash
track create record test today 10:00-1h note +tags
track create record test yesterday 10:00-12:15 note
track create record test 2023-09-01 10:00-12:00 note
```

# Checks

- [x] Implementation of command and core functionality
- [x] Manual testing
- [x] Unit test coverage
- [ ] Documentation